### PR TITLE
URL Cleanup

### DIFF
--- a/config/scdf-app-repo/src/main/resources/templates/repo.html
+++ b/config/scdf-app-repo/src/main/resources/templates/repo.html
@@ -15,7 +15,7 @@
   ~   limitations under the License.
   -->
 
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head>
     <title>SCDF App Repository</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/src/test/java/org/springframework/cloud/dataflow/apptool/AppResourceTests.java
+++ b/src/test/java/org/springframework/cloud/dataflow/apptool/AppResourceTests.java
@@ -25,7 +25,7 @@ import org.junit.Test;
  **/
 public class AppResourceTests {
 
-	private String mavenRepoUrl = "http://my.repo";
+	private String mavenRepoUrl = "https://my.repo";
 	private String jar = "maven://org.springframework.cloud.stream.app:cassandra-sink-rabbit:1.3.1.RELEASE";
 	private String metadata = "maven://org.springframework.cloud.stream"
 		+ ".app:cassandra-sink-rabbit:jar:metadata:1.3.1.RELEASE";
@@ -35,7 +35,7 @@ public class AppResourceTests {
 
 		AppResource appResource = new AppResource("sink.cassandra", jar,mavenRepoUrl);
 
-		assertThat(appResource.getUrl().toString()).isEqualTo("http://my.repo/org/springframework/cloud/stream"
+		assertThat(appResource.getUrl().toString()).isEqualTo("https://my.repo/org/springframework/cloud/stream"
 			+ "/app/cassandra-sink-rabbit/1.3.1.RELEASE/cassandra-sink-rabbit-1.3.1.RELEASE.jar");
 
 		assertThat(appResource.getComponentType()).isEqualTo("sink");
@@ -48,7 +48,7 @@ public class AppResourceTests {
 
 		AppResource appResource = new AppResource("sink.cassandra.metadata", metadata,mavenRepoUrl);
 
-		assertThat(appResource.getUrl().toString()).isEqualTo("http://my.repo/org/springframework/cloud/stream"
+		assertThat(appResource.getUrl().toString()).isEqualTo("https://my.repo/org/springframework/cloud/stream"
 			+ "/app/cassandra-sink-rabbit/1.3.1.RELEASE/cassandra-sink-rabbit-1.3.1.RELEASE-metadata.jar");
 
 		assertThat(appResource.getComponentType()).isEqualTo("sink");


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://my.repo (UnknownHostException) with 1 occurrences migrated to:  
  https://my.repo ([https](https://my.repo) result UnknownHostException).
* [ ] http://my.repo/org/springframework/cloud/stream (UnknownHostException) with 2 occurrences migrated to:  
  https://my.repo/org/springframework/cloud/stream ([https](https://my.repo/org/springframework/cloud/stream) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.thymeleaf.org with 1 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/foo.jar with 1 occurrences
* http://localhost:8080/import with 1 occurrences
* http://localhost:8080/jdbc-source-kafka-10-1.3.1.RELEASE.jar with 1 occurrences
* http://localhost:8080/repo with 2 occurrences